### PR TITLE
✨ Support Alternate Loggers

### DIFF
--- a/lib/json_tagged_logger/formatter.rb
+++ b/lib/json_tagged_logger/formatter.rb
@@ -1,5 +1,5 @@
+require 'active_support'
 require 'active_support/core_ext/hash/keys'
-require 'active_support/tagged_logging'
 require 'json'
 
 module JsonTaggedLogger

--- a/lib/json_tagged_logger/logger.rb
+++ b/lib/json_tagged_logger/logger.rb
@@ -1,5 +1,4 @@
 require 'active_support'
-require 'active_support/tagged_logging'
 
 module JsonTaggedLogger
   module Logger


### PR DESCRIPTION
- e.g. https://github.com/pboling/activesupport-tagged_logging

Since Rails uses autoloading, there is no need to explicitly require `active_support/tagged_logging`, and doing so actively prevents using an alternative.

I have created a suite of gems that replace the Rails logger.  They extract the logging tooling from Rails 8, add in some refactoring and fixes that allow broadcasting, tagged logging, and blocks, to all work together, (which bugs have *always* been present in tagged logging, and remain in v8.0, see [Rails PR 53093][pr-53093] and [Rails PR 53105][pr-53105]).

It works with Rails _because_ of the autoloading.  If a namespace / constant is already defined, it won't go looking for it.  So by defining it in my extracted gems, the vanilla (broken) Rails version doesn't load.

At that point the only problem comes from libraries which load certain Rails internals explicitly.

The suite of gems I'm aiming to have compatibility with is:

- Enhanced [activesupport-logger][activesupport-logger] which was ripped from Rails v8.0
- Enhanced [activesupport-broadcast_logger][activesupport-broadcast_logger] which was ripped from Rails v8.0, and [this PR][pr-53093]
- Enhanced [activesupport-tagged_logging][activesupport-tagged_logging] which was ripped from Rails v8.0, and [this PR][pr-53105]

[activesupport-logger]: https://github.com/pboling/activesupport-logger
[activesupport-broadcast_logger]: https://github.com/pboling/activesupport-broadcast_logger
[activesupport-tagged_logging]: https://github.com/pboling/activesupport-tagged_logging
[pr-53105]: https://github.com/rails/rails/pull/53105
[pr-53093]: https://github.com/rails/rails/pull/53093
