### PR TITLE
Fix old Ruby on Rails verions

### DIFF
--- a/lib/json_tagged_logger.rb
+++ b/lib/json_tagged_logger.rb
@@ -1,3 +1,4 @@
+require 'logger'
 require 'json_tagged_logger/formatter'
 require 'json_tagged_logger/log_tags_config'
 require 'json_tagged_logger/logger'


### PR DESCRIPTION
And CI.

Hints:

* https://stackoverflow.com/q/79360526
* https://github.com/rails/rails/issues/54260
* https://github.com/facebook/react-native/issues/48746

Firstly, I've tried to lock `concurrent-ruby` to an old version, but later I've figured out that we can just require `logger` before Rails.