### PR TITLE
Format time in ISO8601, use UTC and add more precision

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ will get you something like
 ```json
 {
   "level": "INFO",
-  "time": "2025-02-04 18:56:44 +0300",
+  "time": "2025-02-04T18:56:44.711Z",
   "request_id": "914f6104-538d-4ddc-beef-37bfe06ca1c7",
   "host": "127.0.0.1",
   "my_param": "param value",
@@ -71,7 +71,7 @@ Importantly, if the controller action (or any code it calls along the way) has a
 ```json
 {
   "level": "INFO",
-  "time": "2025-02-04 18:56:44 +0300",
+  "time": "2025-02-04T18:56:44.711Z",
   "request_id": "914f6104-538d-4ddc-beef-37bfe06ca1c7",
   "host": "127.0.0.1",
   "my_param": "param value",
@@ -98,7 +98,7 @@ those will be added to the `tags` key in the JSON document
 ```json
 {
   "level": "INFO",
-  "time": "2025-02-04 18:56:44 +0300",
+  "time": "2025-02-04T18:56:44.711Z",
   "request_id": "914f6104-538d-4ddc-beef-37bfe06ca1c7",
   "host": "127.0.0.1",
   "my_param": "param value",

--- a/lib/json_tagged_logger/formatter.rb
+++ b/lib/json_tagged_logger/formatter.rb
@@ -1,6 +1,7 @@
 require 'active_support'
 require 'active_support/core_ext/hash/keys'
 require 'json'
+require 'time'
 
 module JsonTaggedLogger
   class Formatter
@@ -15,7 +16,7 @@ module JsonTaggedLogger
     def call(severity, time, _progname, message)
       log = {
         level: severity,
-        time: time
+        time: time.utc.iso8601(3)
       }
 
       json_tags, text_tags = extract_tags

--- a/test/test_formatter.rb
+++ b/test/test_formatter.rb
@@ -31,11 +31,15 @@ class FormatterTest < Minitest::Test
   def test_json_message_is_merged_with_log_document
     message_hash = { key1: "val1", key2: "val2" }
 
-    @logger.info(message_hash.to_json)
+    fixed_time = Time.now
 
-    expected_json = { level: "INFO", "time": Time.now }.merge(message_hash).to_json + "\n"
+    Time.stub(:now, fixed_time) do
+      @logger.info(message_hash.to_json)
 
-    assert_equal expected_json, @output.string
+      expected_json = { level: "INFO", "time": fixed_time.utc.iso8601(3) }.merge(message_hash).to_json + "\n"
+
+      assert_equal expected_json, @output.string
+    end
   end
 
   def test_plain_tags_are_collected_under_tags_key
@@ -173,32 +177,40 @@ class FormatterTest < Minitest::Test
   def test_optional_pretty_printing
     @logger.formatter.pretty_print = true
 
-    @logger.info("hello world")
+    fixed_time = Time.now
 
-    expected_output = <<~JSON
-    {
-      "level": "INFO",
-      "time": #{Time.now.to_json},
-      "msg": "hello world"
-    }
-    JSON
+    Time.stub(:now, fixed_time) do
+      @logger.info("hello world")
 
-    assert_equal expected_output, @output.string
+      expected_output = <<~JSON
+      {
+        "level": "INFO",
+        "time": "#{fixed_time.utc.iso8601(3)}",
+        "msg": "hello world"
+      }
+      JSON
+
+      assert_equal expected_output, @output.string
+    end
   end
 
   def test_pretty_printing_set_by_initializer
     @logger = JsonTaggedLogger::Logger.new(::Logger.new(@output), pretty_print: true)
 
-    @logger.info("hello world")
+    fixed_time = Time.now
 
-    expected_output = <<~JSON
-    {
-      "level": "INFO",
-      "time": #{Time.now.to_json},
-      "msg": "hello world"
-    }
-    JSON
+    Time.stub(:now, fixed_time) do
+      @logger.info("hello world")
 
-    assert_equal expected_output, @output.string
+      expected_output = <<~JSON
+      {
+        "level": "INFO",
+        "time": "#{fixed_time.utc.iso8601(3)}",
+        "msg": "hello world"
+      }
+      JSON
+
+      assert_equal expected_output, @output.string
+    end
   end
 end


### PR DESCRIPTION
Thanks for this gem!

In high concurrency systems, it is sometimes useful to get timestamps with higher precision (milliseconds) than usual.

It's a kind of "breaking" (because it changes the format of the time and uses UTC), so I'm OK if you do not want to merge this PR :)